### PR TITLE
fix: correct spelling of 'Umamusume' in game registry and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive web application for analyzing cost-effectiveness of in-app purch
 - **Honkai: Star Rail**
 - **Wuthering Waves**
 - **Zenless Zone Zero**
+- **Umamusume: Pretty Derby (Global)**
 
 ## Features
 

--- a/utils/gameRegistry.ts
+++ b/utils/gameRegistry.ts
@@ -182,12 +182,12 @@ const zzzGameData: GameData = {
   },
 }
 
-// Uma Musume: Pretty Derby (Global) Configuration
+// Umamusume: Pretty Derby (Global) Configuration
 const umaGameData: GameData = {
   metadata: {
     id: 'uma',
-    name: 'Uma Musume: Pretty Derby (Global)',
-    shortName: 'Uma Musume',
+    name: 'Umamusume: Pretty Derby (Global)',
+    shortName: 'Umamusume',
 
     currency: {
       name: 'Carats',


### PR DESCRIPTION
## Summary
• Fixed spelling of "Umamusume" in game registry configuration
• Updated README to reflect correct game name
• Corrected both full game name and short name references

🤖 Generated with [Claude Code](https://claude.ai/code)